### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install flake8
+      - name: Lint
+        run: flake8
+      - name: Test
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ pip install -r requirements.txt
 pytest
 ```
 
+Bei jedem Push und für Pull Requests führt ein GitHub Actions Workflow
+(`ci.yml`) `flake8` und `pytest` aus, um sicherzustellen, dass Linting und
+Tests fehlerfrei durchlaufen.
+
 ## Contributing translations
 
 The names of factions and other categories are defined in


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run flake8 and pytest
- mention new CI workflow in README

## Testing
- `flake8` *(fails: E303 too many blank lines, E501 line too long, etc.)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a7ccccabc832f9567265c2f7dbd08