### PR TITLE
Add session retries and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ python scripts/fetch_method.py
 
 Der Aufruf legt die Dateien `data/units.json` und `data/categories.json` an.
 Tritt beim Abrufen ein Netzwerkfehler auf, wird eine `FetchError`-Exception
-ausgelöst. Das Hauptprogramm fängt diese ab, gibt eine Fehlermeldung aus und
-beendet sich mit dem Code `1`. Alle HTTP-Anfragen brechen nach zehn Sekunden
-ohne Antwort mit einem Timeout ab.
+ausgelöst. Das Hauptprogramm fängt diese ab, schreibt eine Fehlermeldung in das
+Log und beendet sich mit dem Code `1`. Alle HTTP-Anfragen verwenden einen
+gemeinsamen `requests.Session` mit automatischen Retries und brechen nach zehn
+Sekunden ohne Antwort mit einem Timeout ab.
 `units.json` enthält die Minis, `categories.json` die verfügbaren Fraktionen,
 Typen, Traits und Geschwindigkeiten.
 Ein Auszug aus `units.json` könnte folgendermaßen aussehen:
@@ -65,6 +66,13 @@ unteren Reihe des Armeefensters gewähren kann. Sind solche Angaben vorhanden,
 werden sie aus `advanced_info` entfernt und in `army_bonus_slots` gespeichert.
 
 Bei jedem Push wird zudem ein GitHub Actions Workflow ausgeführt, der die Datei `data/units.json` automatisch aktualisiert.
+
+
+## Logging
+
+Die Skripte verwenden das Modul `logging`. Über das Argument `--log-level` oder
+die Umgebungsvariable `LOG_LEVEL` lässt sich die gewünschte Protokollstufe
+festlegen. Standardmäßig wird auf `INFO` geloggt.
 
 ## Tests
 

--- a/tests/test_fetch_method.py
+++ b/tests/test_fetch_method.py
@@ -42,7 +42,7 @@ def test_fetch_units_writes_json(tmp_path):
     }
 
     with patch(
-        "scripts.fetch_method.requests.get", return_value=mock_response
+        "scripts.fetch_method.SESSION.get", return_value=mock_response
     ) as mock_get:
         out_file = tmp_path / "units.json"
         cat_file = tmp_path / "categories.json"
@@ -104,7 +104,7 @@ def test_fetch_units_preserves_translations(tmp_path):
     }
 
     with patch(
-        "scripts.fetch_method.requests.get", return_value=mock_response
+        "scripts.fetch_method.SESSION.get", return_value=mock_response
     ) as mock_get:
         out_file = tmp_path / "units.json"
         cat_file = tmp_path / "categories.json"
@@ -157,7 +157,7 @@ def test_fetch_units_skips_unchanged_unit(tmp_path):
     }
 
     with patch(
-        "scripts.fetch_method.requests.get", return_value=mock_response
+        "scripts.fetch_method.SESSION.get", return_value=mock_response
     ) as mock_get:
         out_file = tmp_path / "units.json"
         cat_file = tmp_path / "categories.json"
@@ -220,7 +220,7 @@ def test_fetch_units_updates_changed_unit(tmp_path):
     }
 
     with patch(
-        "scripts.fetch_method.requests.get", return_value=mock_response
+        "scripts.fetch_method.SESSION.get", return_value=mock_response
     ) as mock_get:
         out_file = tmp_path / "units.json"
         cat_file = tmp_path / "categories.json"
@@ -275,7 +275,7 @@ def test_fetch_units_handles_missing_speed_id(tmp_path, speed_value):
     )
     mock_response = Mock(status_code=200, text=html)
     with patch(
-        "scripts.fetch_method.requests.get", return_value=mock_response
+        "scripts.fetch_method.SESSION.get", return_value=mock_response
     ) as mock_get:
         out_file = tmp_path / "units.json"
         dummy_details = {
@@ -314,7 +314,7 @@ def test_speed_id_is_none_when_speed_empty_or_znull(tmp_path, speed_value):
     )
     mock_response = Mock(status_code=200, text=html)
     with patch(
-        "scripts.fetch_method.requests.get", return_value=mock_response
+        "scripts.fetch_method.SESSION.get", return_value=mock_response
     ) as mock_get:
         out_file = tmp_path / "units.json"
         dummy_details = {
@@ -355,7 +355,7 @@ def test_fetch_unit_details_army_bonus_slots_removed():
     mock_response = Mock(status_code=200, text=html)
 
     with patch(
-        "scripts.fetch_method.requests.get", return_value=mock_response
+        "scripts.fetch_method.SESSION.get", return_value=mock_response
     ) as mock_get:
         details = fetch_method.fetch_unit_details("url")
         mock_get.assert_called_once_with(
@@ -382,7 +382,7 @@ def test_fetch_unit_details_returns_trait_ids():
     mock_response = Mock(status_code=200, text=html)
 
     with patch(
-        "scripts.fetch_method.requests.get", return_value=mock_response
+        "scripts.fetch_method.SESSION.get", return_value=mock_response
     ) as mock_get, patch(
         "scripts.fetch_method.load_categories",
         return_value={
@@ -418,7 +418,7 @@ def test_fetch_unit_details_core_trait_ids():
     mock_response = Mock(status_code=200, text=html)
 
     with patch(
-        "scripts.fetch_method.requests.get", return_value=mock_response
+        "scripts.fetch_method.SESSION.get", return_value=mock_response
     ) as mock_get, patch(
         "scripts.fetch_method.load_categories",
         return_value={
@@ -440,7 +440,7 @@ def test_fetch_unit_details_core_trait_ids():
 def test_fetch_unit_details_request_exception():
     """Die Funktion soll bei Netzwerkfehlern mit Code 1 beenden."""
     with patch(
-        "scripts.fetch_method.requests.get",
+        "scripts.fetch_method.SESSION.get",
         side_effect=requests.RequestException("boom"),
     ) as mock_get:
         with pytest.raises(fetch_method.FetchError) as excinfo:
@@ -454,7 +454,7 @@ def test_fetch_unit_details_request_exception():
 def test_fetch_units_request_exception(tmp_path):
     """Die Funktion soll bei Netzwerkfehlern mit Code 1 beenden."""
     with patch(
-        "scripts.fetch_method.requests.get",
+        "scripts.fetch_method.SESSION.get",
         side_effect=requests.RequestException("boom"),
     ) as mock_get, patch.object(fetch_method, "OUT_PATH", tmp_path / "units.json"):
         with pytest.raises(fetch_method.FetchError) as excinfo:
@@ -465,3 +465,7 @@ def test_fetch_units_request_exception(tmp_path):
             timeout=10,
         )
     assert "Fehler beim Abrufen" in str(excinfo.value)
+
+
+def test_session_retry_adapter():
+    assert fetch_method.adapter.max_retries.total == 3


### PR DESCRIPTION
## Summary
- add requests session with retries and structured logging
- make log level configurable via CLI flag or `LOG_LEVEL`
- rewrite fetch script output to use logging
- adjust unit tests to new session usage and verify retry adapter
- document new logging and retry behavior

## Testing
- `black scripts tests`
- `flake8 scripts tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a87fe8040832fa0308f4e4c44a5f5