### PR TITLE
Add Railway log capture step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
           pip install -r requirements-dev.txt
       - name: Prepare logs directory
         run: mkdir -p logs
+      - name: Capture Railway logs
+        run: railway logs --follow > logs/latest_railway.log &
       - name: Run pre-commit
         run: pre-commit run --all-files --show-diff-on-failure --color=always
       - name: Test
@@ -39,6 +41,9 @@ jobs:
         run: |
           coverage xml
           coverage report --fail-under=90
+      - name: Stop Railway logs
+        if: always()
+        run: pkill railway
       - name: Upload logs
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- capture Railway logs during CI
- stop the log capture before uploading artifacts

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c78efab00832f91cbf1a902e4457e