### PR TITLE
Add CycloneDX SBOM generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,12 @@ jobs:
           echo $! > logs/railway_logs.pid
       - name: Run pre-commit
         run: pre-commit run --all-files --show-diff-on-failure --color=always
+      - name: Archive SBOM
+        if: always()
+        run: |
+          if [ -f sbom.xml ]; then
+            mv sbom.xml logs/
+          fi
       - name: Test
         run: coverage run -m pytest --timeout=60
       - name: Coverage report
@@ -56,5 +62,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: logs
-          path: logs/latest_railway.log
+          path: logs/
           if-no-files-found: ignore

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,8 @@ repos:
       - id: pip-audit
         additional_dependencies: ["pip-audit[cyclonedx]", "cyclonedx-bom"]
         args: ["-r", "requirements.txt", "--format", "columns"]
+  - repo: https://github.com/CycloneDX/cyclonedx-python
+    rev: v6.1.1
+    hooks:
+      - id: cyclonedx-bom
+        args: ["-o", "sbom.xml"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,8 +27,11 @@ repos:
       - id: pip-audit
         additional_dependencies: ["pip-audit[cyclonedx]", "cyclonedx-bom"]
         args: ["-r", "requirements.txt", "--format", "columns"]
-  - repo: https://github.com/CycloneDX/cyclonedx-python
-    rev: v6.1.1
+  - repo: local
     hooks:
       - id: cyclonedx-bom
-        args: ["-o", "sbom.xml"]
+        name: cyclonedx-bom
+        entry: cyclonedx-py env -o sbom.xml
+        language: python
+        additional_dependencies: ["cyclonedx-bom"]
+        pass_filenames: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Tests for the new behaviors.
 - Structured JSON logging via `configure_structlog`.
 - Pre-commit configuration and CI integration.
+- SBOM generation via `cyclonedx-bom` and CI archiving.
 - Security scan workflow using Snyk.
 - Unit tests for structured logging.
 - Package moved to `src/` layout.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ pip install -r requirements-dev.txt
 pre-commit install
 pre-commit run --all-files
 ```
+Running pre-commit also creates an SBOM via `cyclonedx-bom`, saved as
+`sbom.xml`.
 
 Run the tests with:
 


### PR DESCRIPTION
## Summary
- add cyclonedx-bom to pre-commit config
- move generated sbom.xml to logs and archive in CI
- mention SBOM in README
- document SBOM addition in CHANGELOG

## Testing
- `pre-commit run --all-files` *(fails: InvalidManifestError)*
- `coverage run -m pytest --timeout=60`
- `coverage xml`
- `coverage report --fail-under=90`


------
https://chatgpt.com/codex/tasks/task_e_685c85e15a0c832fb73e2e9b81744296