### PR TITLE
Improve linting and security setup

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,6 +15,7 @@ jobs:
           python-version: '3.11'
       - run: pip install -r requirements.txt
       - name: Snyk Scan
+        if: ${{ secrets.SNYK_TOKEN != '' && github.event.pull_request.head.repo.full_name == github.repository }}
         uses: snyk/actions/python@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ logs/
 # Misc
 .env
 sbom.xml
+.pytest_cache/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/pypa/pip-audit
-    rev: v2.7.2
+    rev: v2.9.0
     hooks:
       - id: pip-audit
         additional_dependencies: ["pip-audit[cyclonedx]", "cyclonedx-bom"]

--- a/README.md
+++ b/README.md
@@ -69,15 +69,17 @@ errors are in German.
 
 ## Development
 
-Formatting and linting are enforced via [pre-commit](https://pre-commit.com/):
+Formatting, linting and dependency checks are enforced via
+[pre-commit](https://pre-commit.com/):
 
 ```bash
 pip install -r requirements-dev.txt
 pre-commit install
 pre-commit run --all-files
 ```
-Running pre-commit also creates an SBOM via `cyclonedx-bom`, saved as
-`sbom.xml`.
+Running `pre-commit` formats the code, lints it with Black, Ruff and
+Flake8, scans the requirements with `pip-audit` and creates an SBOM via
+`cyclonedx-bom` which is saved as `sbom.xml`.
 
 Run the tests with:
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,5 +5,5 @@ coverage==7.9.1
 pre-commit==3.7.1
 ruff==0.4.4
 pytest-timeout==2.3.1
-pip-audit==2.7.2
+pip-audit==2.9.0
 cyclonedx-bom==6.1.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,5 @@ coverage==7.9.1
 pre-commit==3.7.1
 ruff==0.4.4
 pytest-timeout==2.3.1
+pip-audit==2.7.2
+cyclonedx-bom==6.1.1


### PR DESCRIPTION
## Summary
- run Snyk only when secrets are available
- ignore pytest cache
- explain `pre-commit` usage
- document lint and security dependencies

## Testing
- `pre-commit run --files README.md .github/workflows/security.yml .gitignore requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c1b58d208832f8bc0e0e8b0616181