### PR TITLE
Improve Dependabot docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,4 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
 - CI uploads Railway logs as artifacts.
 - Unit test ensuring sessions close when created.
 - Dependabot configuration for automated dependency updates.
+- Dependabot now checks Python dependencies daily and its pull requests run
+  the complete CI pipeline.
 
 ### Changed
 - GitHub Actions workflow uses explicit paths when updating data.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ pytest  # fails after 60s if a test hangs
 
 CI executes `pre-commit` and the test suite with coverage ≥90 %.
 A scheduled workflow performs a Snyk security scan.
-Dependabot creates pull requests to update Python and GitHub Actions dependencies, and alerts are enabled for vulnerable packages.
+Dependabot checks Python requirements every day (GitHub Actions weekly) and its pull
+requests trigger the full CI pipeline with linting, testing and `pip-audit`.
 
 ## Deployment
 


### PR DESCRIPTION
## Summary
- clarify daily Dependabot runs in README
- document Dependabot CI trigger in CHANGELOG
- set pull request limit in Dependabot config

## Testing
- `pytest -q`
- `pre-commit run --files .github/dependabot.yml README.md CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_685c957c4fa4832f8095ed3a1ee746c0