### PR TITLE
Improve logging and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ python -m wcr_data_extraction.cli \
   --categories data/categories.json \
   --timeout 10 \
   --workers 4 \
-  --log-level INFO
+  --log-level INFO \
+  --log-file logs/wcr.log
 ```
 
 `--timeout` and `--workers` accept positive integers. Data is fetched with a
@@ -63,8 +64,8 @@ A GitHub Actions workflow updates `data/units.json` on every push to `main`.
 ## Logging
 
 Structured JSON logs are configured via `configure_structlog()` or the
-`--log-level` option. When a log file is provided, messages are written to
-`logs/wcr.log` with rotation. Internal logs are English while user-facing
+`--log-level` option. By default logs are written to `logs/wcr.log` with
+rotation. Internal logs are English while user-facing
 errors are in German.
 
 ## Development

--- a/src/wcr_data_extraction/cli.py
+++ b/src/wcr_data_extraction/cli.py
@@ -39,6 +39,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--workers", type=positive_int, default=1, help="Number of parallel workers"
     )
     parser.add_argument("--log-level", default="INFO", help="Logging level")
+    parser.add_argument(
+        "--log-file",
+        default="logs/wcr.log",
+        help="Path to the log file (stored under logs/)",
+    )
     return parser.parse_args(argv)
 
 
@@ -46,7 +51,7 @@ def main(argv: list[str] | None = None) -> None:
     """Entry point for the command line."""
 
     args = parse_args(argv)
-    configure_structlog(args.log_level)
+    configure_structlog(args.log_level, Path(args.log_file))
     try:
         fetch_units(
             out_path=Path(args.output),

--- a/tests/test_async_example.py
+++ b/tests/test_async_example.py
@@ -1,8 +1,0 @@
-import asyncio
-import pytest
-
-
-@pytest.mark.asyncio
-async def test_async_example():
-    await asyncio.sleep(0.01)
-    assert True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,6 +15,7 @@ def test_parse_args_defaults(tmp_path):
         assert Path(args.categories) == tmp_path / "categories.json"
         assert args.timeout == 10
         assert args.workers == 1
+        assert Path(args.log_file) == Path("logs/wcr.log")
 
 
 def test_main_invokes_fetch_units(tmp_path):
@@ -32,7 +33,7 @@ def test_main_invokes_fetch_units(tmp_path):
         cli, "fetch_units"
     ) as mock_fetch:
         cli.main(args)
-        mock_conf.assert_called_once_with("DEBUG")
+        mock_conf.assert_called_once_with("DEBUG", Path("logs/wcr.log"))
         mock_fetch.assert_called_once_with(
             out_path=Path(args[1]),
             categories_path=Path(args[3]),


### PR DESCRIPTION
## Summary
- add log file option to CLI and pass to logging setup
- update docs to show default `logs/wcr.log`
- adjust CLI tests for the new flag
- remove unused async test

## Testing
- `pre-commit run --files src/wcr_data_extraction/cli.py tests/test_cli.py README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c9932bde0832f942de73646a1bac8