### PR TITLE
Fix Snyk workflow condition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,10 @@ jobs:
       - name: Coverage report
         run: coverage report --fail-under=90
       - name: Snyk Test
-        if: ${{ secrets.SNYK_TOKEN != '' && github.event.pull_request.head.repo.full_name == github.repository }}
-        run: snyk test
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        if: github.event.pull_request.head.repo.full_name == github.repository && env.SNYK_TOKEN != ''
+        run: snyk test
       - name: Stop Railway logs
         if: always()
         run: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,6 +1,8 @@
 name: Security Scan
 
 on:
+  push:
+  pull_request:
   schedule:
     - cron: '0 3 * * 0'
   workflow_dispatch:
@@ -15,9 +17,9 @@ jobs:
           python-version: '3.11'
       - run: pip install -r requirements.txt
       - name: Snyk Scan
-        if: ${{ secrets.SNYK_TOKEN != '' && github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: snyk/actions/python@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        if: github.event.pull_request.head.repo.full_name == github.repository && env.SNYK_TOKEN != ''
+        uses: snyk/actions/python@master
         with:
           command: test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,3 +48,5 @@
 - README and CHANGELOG brought in line with the global structure.
 - Clarified example environment file and added explanatory comments.
 - CI: Skip Snyk test in forked PRs to prevent missing-secret auth errors.
+- Security workflow now runs on pushes and pull requests and gracefully skips
+  Snyk scans when the token is absent.


### PR DESCRIPTION
## Summary
- allow `security.yml` to run on push and pull_request events
- guard Snyk steps using env-based condition pattern
- document workflow behaviour in CHANGELOG

## Testing
- `pre-commit run --files .github/workflows/security.yml .github/workflows/ci.yml CHANGELOG.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d2745c278832f96beb9c331f6f8fa