### PR TITLE
Improve CI and logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,5 @@
 # Tokens used by GitHub Actions workflows
 SNYK_TOKEN=
 RAILWAY_TOKEN=
+RAILWAY_PROJECT=
+RAILWAY_SERVICE=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,14 +27,16 @@ jobs:
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
       - name: Install Railway CLI
-        run: npm install -g railway
+        run: npx railway --version
       - name: Prepare logs directory
         run: mkdir -p logs
       - name: Capture Railway logs
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_PROJECT: ${{ secrets.RAILWAY_PROJECT }}
+          RAILWAY_SERVICE: ${{ secrets.RAILWAY_SERVICE }}
         run: |
-          railway logs --follow > logs/latest_railway.log &
+          npx railway logs --service "$RAILWAY_SERVICE" --project "$RAILWAY_PROJECT" --env production --json --follow > logs/latest_railway.log &
           echo $! > logs/railway_logs.pid
       - name: Run pre-commit
         run: pre-commit run --all-files --show-diff-on-failure --color=always

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,17 @@
+name: Enable Auto-Merge for Dependabot
+
+on:
+  pull_request:
+    types: [opened, labeled]
+    branches: [main]
+
+jobs:
+  automerge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          merge-method: squash

--- a/.github/workflows/railway_logs.yml
+++ b/.github/workflows/railway_logs.yml
@@ -9,13 +9,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Railway CLI
-        run: npm install -g railway
+        run: npx railway --version
       - name: Fetch logs
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_PROJECT: ${{ secrets.RAILWAY_PROJECT }}
+          RAILWAY_SERVICE: ${{ secrets.RAILWAY_SERVICE }}
         run: |
           mkdir -p logs
-          railway logs --follow > logs/latest_railway.log
+          npx railway logs --service "$RAILWAY_SERVICE" --project "$RAILWAY_PROJECT" --env production --json --follow > logs/latest_railway.log
       - uses: actions/upload-artifact@v4
         with:
           name: railway-logs

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,3 +21,18 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         if: ${{ env.SNYK_TOKEN != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
         run: snyk test
+
+  codeql:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: github/codeql-action/init@v2
+      - uses: github/codeql-action/analyze@v2
+
+  trufflehog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: trufflesecurity/trufflehog@v3
+        with:
+          path: ./
+        continue-on-error: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,3 +52,9 @@
 - README and CHANGELOG brought in line with the global structure.
 - Clarified example environment file and added explanatory comments.
 - CI: Skip Snyk test in forked PRs to prevent missing-secret auth errors.
+- Hourly log rotation with `TimedRotatingFileHandler`.
+- Default log file name `runtime-<YYYY-MM-DD-HH>.json`.
+- Wrapper script now uses `argparse` and supports `--help`.
+- Workflows use `npx` for Railway CLI and include project/service IDs.
+- Security workflow runs CodeQL and TruffleHog scans.
+- Dependabot auto-merge workflow.

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Copy `.env.example` to `.env` if you need to define environment variables. None 
 
 ### Environment variables
 
-`SNYK_TOKEN` and `RAILWAY_TOKEN` are used by the GitHub Actions workflows for
-security scanning and fetching Railway logs. Leave them empty if you do not use
-those features.
+`SNYK_TOKEN`, `RAILWAY_TOKEN`, `RAILWAY_PROJECT` and `RAILWAY_SERVICE` are used
+by the GitHub Actions workflows for security scanning and fetching Railway
+logs. Leave them empty if you do not use those features.
 
 ## Usage
 
@@ -26,18 +26,18 @@ python -m wcr_data_extraction.cli \
   --timeout 10 \
   --workers 4 \
   --log-level INFO \
-  --log-file logs/wcr.log
+  --log-file logs/runtime-YYYY-MM-DD-HH.json
 ```
 
 `--timeout` and `--workers` must be positive integers. Results are written atomically so existing files stay intact on errors.
 
 ## Utility Scripts
 
-- `python scripts/fetch_method.py` – wrapper around the main CLI. All arguments are forwarded as-is.
+- `python scripts/fetch_method.py` – wrapper around the main CLI. Run with `--help` to see available options; all arguments are forwarded as-is.
 
 ## Logging
 
-Structured JSON logs are configured via `configure_structlog()` or the `--log-level` option. By default logs are written to `logs/wcr.log` with rotation. Internal logs are in English while user-facing errors are in German.
+Structured JSON logs are configured via `configure_structlog()` or the `--log-level` option. By default logs are written to `logs/runtime-<YYYY-MM-DD-HH>.json` with hourly rotation. Internal logs are in English while user-facing errors are in German.
 
 ## Development
 
@@ -67,7 +67,9 @@ Deploy the extractor to [Railway](https://railway.app/). Set the start command t
 python -m wcr_data_extraction.cli --output data/units.json --categories data/categories.json
 ```
 
-The `railway_logs` workflow streams service logs with `railway logs --follow` and uploads them as artifacts.
+The `railway_logs` workflow streams service logs with
+`npx railway logs --service <service> --project <project> --env production --json --follow`
+and uploads them as artifacts.
 
 ## Contributing translations
 

--- a/scripts/fetch_method.py
+++ b/scripts/fetch_method.py
@@ -4,6 +4,7 @@ This script provides a stable entry point for fetching unit data. All command
 line arguments are passed directly to :mod:`wcr_data_extraction.cli`.
 """
 
+import argparse
 from pathlib import Path
 import sys
 from typing import List
@@ -14,8 +15,18 @@ from wcr_data_extraction import cli  # noqa: E402
 
 
 def main(argv: List[str] | None = None) -> None:
-    """Execute the CLI with the given arguments."""
-    cli.main(argv)
+    """Execute the extractor CLI.
+
+    Parameters are forwarded directly to :mod:`wcr_data_extraction.cli`. Use
+    ``--help`` to see available options.
+    """
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--help", action="store_true", help="Show help message")
+    args, rest = parser.parse_known_args(argv)
+    if args.help:
+        cli.main(["--help"])
+    else:
+        cli.main(rest)
 
 
 if __name__ == "__main__":

--- a/src/wcr_data_extraction/cli.py
+++ b/src/wcr_data_extraction/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import sys
+from datetime import datetime
 from pathlib import Path
 
 from .fetcher import (
@@ -41,7 +42,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--log-level", default="INFO", help="Logging level")
     parser.add_argument(
         "--log-file",
-        default="logs/wcr.log",
+        default=f"logs/runtime-{datetime.now():%Y-%m-%d-%H}.json",
         help="Path to the log file (stored under logs/)",
     )
     return parser.parse_args(argv)

--- a/src/wcr_data_extraction/fetcher.py
+++ b/src/wcr_data_extraction/fetcher.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
-from logging.handlers import RotatingFileHandler
+from logging.handlers import TimedRotatingFileHandler
 import structlog
 from pathlib import Path
 from typing import Iterable
@@ -53,8 +53,12 @@ def configure_structlog(level: str, log_file: str | Path | None = None) -> None:
     if log_file is not None:
         Path(log_file).parent.mkdir(parents=True, exist_ok=True)
         handlers.append(
-            RotatingFileHandler(
-                log_file, maxBytes=1_000_000, backupCount=3, encoding="utf-8"
+            TimedRotatingFileHandler(
+                log_file,
+                when="H",
+                interval=1,
+                backupCount=0,
+                encoding="utf-8",
             )
         )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,7 +15,8 @@ def test_parse_args_defaults(tmp_path):
         assert Path(args.categories) == tmp_path / "categories.json"
         assert args.timeout == 10
         assert args.workers == 1
-        assert Path(args.log_file) == Path("logs/wcr.log")
+        assert Path(args.log_file).parent == Path("logs")
+        assert Path(args.log_file).name.startswith("runtime-")
 
 
 def test_main_invokes_fetch_units(tmp_path):
@@ -33,7 +34,9 @@ def test_main_invokes_fetch_units(tmp_path):
         cli, "fetch_units"
     ) as mock_fetch:
         cli.main(args)
-        mock_conf.assert_called_once_with("DEBUG", Path("logs/wcr.log"))
+        called_path = mock_conf.call_args.args[1]
+        assert called_path.parent == Path("logs")
+        assert called_path.name.startswith("runtime-")
         mock_fetch.assert_called_once_with(
             out_path=Path(args[1]),
             categories_path=Path(args[3]),


### PR DESCRIPTION
## Summary
- rotate runtime logs hourly
- dynamic log file name in CLI
- improve wrapper script with argparse
- update workflows to use `npx railway`
- document Railway project/service variables
- add CodeQL and TruffleHog scans
- enable Dependabot auto-merge

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e7566d558832f93ae310e4bec27be