### PR TITLE
Improve publish workflow robustness

### DIFF
--- a/.github/workflows/publish-data.yml
+++ b/.github/workflows/publish-data.yml
@@ -22,12 +22,30 @@ jobs:
       - name: Install dependencies
         run: ./setup.sh
 
+      - name: Prepare folders
+        run: |
+          mkdir -p tmp_data logs data
+
       - name: Run extractor to tmp_data/
         run: |
-          mkdir -p tmp_data
           python scripts/fetch_method.py \
             --output tmp_data/units.json \
-            --categories tmp_data/categories.json
+            --categories tmp_data/categories.json \
+            --log-file logs/extractor.json
+
+      - name: Validate JSON output
+        run: |
+          for f in units.json categories.json; do
+            path="tmp_data/$f"
+            if [ ! -s "$path" ] || [ $(stat -c%s "$path") -le 2 ]; then
+              echo "$f missing or empty" >&2
+              exit 1
+            fi
+            python -m json.tool "$path" > /dev/null || {
+              echo "$f is invalid JSON" >&2
+              exit 1
+            }
+          done
 
       - name: Copy JSON files
         run: |
@@ -54,6 +72,15 @@ jobs:
           git switch data-sync
           git pull origin data-sync || true
 
+          if [ ! -s data/units.json ] || [ $(stat -c%s data/units.json) -le 2 ]; then
+            echo "units.json missing or empty" >&2
+            exit 1
+          fi
+          if [ ! -s data/categories.json ] || [ $(stat -c%s data/categories.json) -le 2 ]; then
+            echo "categories.json missing or empty" >&2
+            exit 1
+          fi
+
           git add -f data/units.json data/categories.json 2>/dev/null || true
 
           if git diff --cached --quiet; then
@@ -63,3 +90,11 @@ jobs:
 
           git commit -m "Update data from main [CI]"
           git push origin data-sync
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: extractor-logs
+          path: logs/
+          if-no-files-found: ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
 - Atomic writes when saving `units.json`.
 - Warning logs when `load_categories` fails to read the file.
 - Helper `create_session` for injecting custom HTTP sessions.
+- Validation in publish workflow ensures JSON files are non-empty and valid.
+- Requirements now include explicit `urllib3` dependency.
+- `setup.sh` fails fast on installation errors.
 - Tests for the new behaviors.
 - Structured JSON logging via `configure_structlog`.
 - Pre-commit configuration and CI integration.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Simple scraper that downloads minis from [method.gg](https://www.method.gg/warcr
 ./setup.sh             # install runtime requirements
 ./setup.sh --dev       # additionally install development tools
 ```
+The script aborts with an error message if installation fails.
 
 Copy `.env.example` to `.env` if you need to define environment variables. None are required by default.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests==2.32.4
+urllib3==2.5.0
 beautifulsoup4==4.13.4
 structlog==24.1.0

--- a/setup.sh
+++ b/setup.sh
@@ -1,8 +1,16 @@
 #!/bin/bash
+set -e
+
 # Install required Python packages
-python3 -m pip install -r requirements.txt
+if ! python3 -m pip install -r requirements.txt; then
+    echo "Failed to install runtime requirements" >&2
+    exit 1
+fi
 
 if [ "$1" = "--dev" ]; then
     # Install development tools as well
-    python3 -m pip install -r requirements-dev.txt
+    if ! python3 -m pip install -r requirements-dev.txt; then
+        echo "Failed to install development requirements" >&2
+        exit 1
+    fi
 fi


### PR DESCRIPTION
## Summary
- include `urllib3` in runtime dependencies
- fail fast in setup script
- validate data files in `publish-data` workflow
- upload extractor logs if something goes wrong
- document setup script behaviour

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e908d0528832fa32bfc41bda141bc