### PR TITLE
Add category scraping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Command-line interface for `fetch_method.py` with `--output`, `--categories` and `--timeout` options.
 - New unit tests for CLI parsing.
 - Development requirements file and optional `--dev` flag for `setup.sh`.
+- Automatic fetching of category data to `categories.json`.
 - Section in README on updating dependencies.
 - Package refactored into `wcr_data_extraction` with `cli` module.
 - Parallel download support via `--workers`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Warcraft Rumble Data Extractor
 
-Simple scraper that downloads minis from [method.gg](https://www.method.gg/warcraft-rumble/minis). The result is written to `data/units.json` which is ignored by Git. Optionally you can provide a category mapping in `data/categories.json`.
+Simple scraper that downloads minis and category data from [method.gg](https://www.method.gg/warcraft-rumble/minis). Results are written to `data/units.json` and `data/categories.json`, both ignored by Git.
 
 ## Setup
 
@@ -34,7 +34,7 @@ python -m wcr_data_extraction.cli \
 
 ## Utility Scripts
 
-- `python scripts/fetch_method.py` – wrapper around the main CLI. Run with `--help` to see available options; all arguments are forwarded as-is.
+- `python scripts/fetch_method.py` – fetches units and categories from method.gg. Run with `--help` to see available options; arguments mirror the CLI.
 
 ## Logging
 

--- a/scripts/fetch_method.py
+++ b/scripts/fetch_method.py
@@ -1,7 +1,7 @@
 """Wrapper for the ``wcr_data_extraction`` CLI.
 
-This script provides a stable entry point for fetching unit data. All command
-line arguments are passed directly to :mod:`wcr_data_extraction.cli`.
+This script provides a stable entry point for fetching unit and category data.
+All command line arguments are passed directly to :mod:`wcr_data_extraction.cli`.
 """
 
 import argparse
@@ -12,6 +12,13 @@ from typing import List
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
 from wcr_data_extraction import cli  # noqa: E402
+from wcr_data_extraction.fetcher import (  # noqa: E402
+    fetch_units,
+    fetch_categories,
+    configure_structlog,
+    FetchError,
+    logger,
+)
 
 
 def main(argv: List[str] | None = None) -> None:
@@ -25,8 +32,22 @@ def main(argv: List[str] | None = None) -> None:
     args, rest = parser.parse_known_args(argv)
     if args.help:
         cli.main(["--help"])
-    else:
-        cli.main(rest)
+        return
+
+    parsed = cli.parse_args(rest)
+    configure_structlog(parsed.log_level, Path(parsed.log_file))
+    try:
+        logger.info("Starting fetch")
+        fetch_categories(out_path=Path(parsed.categories), timeout=parsed.timeout)
+        fetch_units(
+            out_path=Path(parsed.output),
+            categories_path=Path(parsed.categories),
+            timeout=parsed.timeout,
+            max_workers=parsed.workers,
+        )
+    except FetchError as exc:
+        logger.error("Fehler beim Abrufen: %s", exc)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/src/wcr_data_extraction/__init__.py
+++ b/src/wcr_data_extraction/__init__.py
@@ -2,6 +2,7 @@
 
 from .fetcher import (
     fetch_units,
+    fetch_categories,
     load_categories,
     load_existing_units,
     is_unit_changed,
@@ -12,6 +13,7 @@ from .fetcher import (
 
 __all__ = [
     "fetch_units",
+    "fetch_categories",
     "load_categories",
     "load_existing_units",
     "is_unit_changed",

--- a/tests/test_fetch_categories.py
+++ b/tests/test_fetch_categories.py
@@ -1,0 +1,85 @@
+import json
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import requests
+
+import pytest
+
+from wcr_data_extraction import fetcher
+
+
+def make_html():
+    return """
+    <div class='mini-wrapper' data-family='Alliance' data-speed='Slow'></div>
+    <div class='mini-wrapper' data-family='Alliance,Undead' data-speed='Fast'></div>
+    <div class='filter__type'>
+        <input data-for='type' data-value='Leader'/>
+        <input data-for='type' data-value='Spell'/>
+    </div>
+    <div class='filter__trait'>
+        <input data-for='traits' data-value='Ambush'/>
+        <input data-for='traits' data-value='AoE'/>
+    </div>
+    """
+
+
+def test_fetch_categories_writes_json(tmp_path):
+    html = make_html()
+    mock_response = Mock(status_code=200, text=html)
+    mock_session = Mock()
+    mock_session.get.return_value = mock_response
+    with patch.object(fetcher, "create_session", return_value=mock_session):
+        out_file = tmp_path / "cats.json"
+        with patch.object(fetcher, "CATEGORIES_PATH", out_file):
+            fetcher.fetch_categories(session=mock_session)
+    data = json.loads(out_file.read_text())
+    faction_ids = {f["id"] for f in data["factions"]}
+    assert "alliance" in faction_ids
+    assert "alliance-undead" in faction_ids
+    type_ids = {t["id"] for t in data["types"]}
+    assert type_ids == {"leader", "spell"}
+    trait_ids = {t["id"] for t in data["traits"]}
+    assert trait_ids == {"ambush", "aoe"}
+    speed_ids = {s["id"] for s in data["speeds"]}
+    assert speed_ids == {"slow", "fast"}
+
+
+def test_fetch_categories_preserves_translations(tmp_path):
+    html = make_html()
+    mock_response = Mock(status_code=200, text=html)
+    mock_session = Mock()
+    mock_session.get.return_value = mock_response
+    existing = {
+        "factions": [{"id": "alliance", "names": {"en": "Alliance", "de": "Allianz"}}],
+        "types": [],
+        "traits": [],
+        "speeds": [],
+    }
+    out_file = tmp_path / "cats.json"
+    out_file.write_text(json.dumps(existing))
+    with patch.object(fetcher, "create_session", return_value=mock_session):
+        with patch.object(fetcher, "CATEGORIES_PATH", out_file):
+            fetcher.fetch_categories(session=mock_session)
+    data = json.loads(out_file.read_text())
+    alliance = next(x for x in data["factions"] if x["id"] == "alliance")
+    assert alliance["names"]["de"] == "Allianz"
+
+
+def test_fetch_categories_request_exception(tmp_path):
+    mock_session = Mock()
+    mock_session.get.side_effect = requests.RequestException("boom")
+    with patch.object(fetcher, "create_session", return_value=mock_session):
+        with patch.object(fetcher, "CATEGORIES_PATH", tmp_path / "c.json"):
+            with pytest.raises(fetcher.FetchError):
+                fetcher.fetch_categories(session=mock_session)
+
+
+def test_fetch_categories_http_error(tmp_path):
+    mock_response = Mock(status_code=500, text="")
+    mock_session = Mock()
+    mock_session.get.return_value = mock_response
+    with patch.object(fetcher, "create_session", return_value=mock_session):
+        with patch.object(fetcher, "CATEGORIES_PATH", tmp_path / "c.json"):
+            with pytest.raises(fetcher.FetchError):
+                fetcher.fetch_categories(session=mock_session)

--- a/tests/test_fetch_categories.py
+++ b/tests/test_fetch_categories.py
@@ -1,5 +1,4 @@
 import json
-from pathlib import Path
 from unittest.mock import Mock, patch
 
 import requests

--- a/tests/test_fetch_script.py
+++ b/tests/test_fetch_script.py
@@ -1,10 +1,10 @@
-from argparse import Namespace
+import sys
 from pathlib import Path
+from argparse import Namespace
 from unittest.mock import patch
 
-import sys
 sys.path.append(str(Path(__file__).resolve().parents[1]))
-from scripts import fetch_method
+from scripts import fetch_method  # noqa: E402
 
 
 def test_script_invokes_fetchers(tmp_path):

--- a/tests/test_fetch_script.py
+++ b/tests/test_fetch_script.py
@@ -1,0 +1,31 @@
+from argparse import Namespace
+from pathlib import Path
+from unittest.mock import patch
+
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from scripts import fetch_method
+
+
+def test_script_invokes_fetchers(tmp_path):
+    args = Namespace(
+        output=str(tmp_path / "u.json"),
+        categories=str(tmp_path / "c.json"),
+        timeout=5,
+        workers=2,
+        log_level="INFO",
+        log_file=str(tmp_path / "log.json"),
+    )
+    with patch.object(fetch_method.cli, "parse_args", return_value=args):
+        with patch.object(fetch_method, "configure_structlog") as conf, patch.object(
+            fetch_method, "fetch_categories"
+        ) as fc, patch.object(fetch_method, "fetch_units") as fu:
+            fetch_method.main([])
+            conf.assert_called_once_with("INFO", Path(args.log_file))
+            fc.assert_called_once_with(out_path=Path(args.categories), timeout=5)
+            fu.assert_called_once_with(
+                out_path=Path(args.output),
+                categories_path=Path(args.categories),
+                timeout=5,
+                max_workers=2,
+            )

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -25,3 +25,13 @@ def test_fetch_units_closes_created_session(tmp_path):
         ):
             fetcher.fetch_units()
     mock_session.close.assert_called_once()
+
+
+def test_fetch_categories_closes_created_session(tmp_path):
+    mock_session = Mock()
+    mock_session.get.return_value.status_code = 200
+    mock_session.get.return_value.text = "<div></div>"
+    with patch.object(fetcher, "create_session", return_value=mock_session):
+        with patch.object(fetcher, "CATEGORIES_PATH", tmp_path / "c.json"):
+            fetcher.fetch_categories()
+    mock_session.close.assert_called_once()


### PR DESCRIPTION
## Summary
- fetch categories from method.gg with new `fetch_categories`
- run category fetching in `scripts/fetch_method.py`
- export new helper in package
- document script behavior
- cover new code with tests

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e97b87eb8832fac966c932990efe4