### PR TITLE
Add category scraping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Command-line interface for `fetch_method.py` with `--output`, `--categories` and `--timeout` options.
 - New unit tests for CLI parsing.
 - Development requirements file and optional `--dev` flag for `setup.sh`.
+- Automatic fetching of category data to `categories.json`.
+- Errors are raised when no categories or units are found.
 - Section in README on updating dependencies.
 - Package refactored into `wcr_data_extraction` with `cli` module.
 - Parallel download support via `--workers`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Warcraft Rumble Data Extractor
 
-Simple scraper that downloads minis from [method.gg](https://www.method.gg/warcraft-rumble/minis). The result is written to `data/units.json` which is ignored by Git. Optionally you can provide a category mapping in `data/categories.json`.
+Simple scraper that downloads minis and category data from [method.gg](https://www.method.gg/warcraft-rumble/minis). Results are written to `data/units.json` and `data/categories.json`, both ignored by Git.
 
 ## Setup
 
@@ -34,7 +34,7 @@ python -m wcr_data_extraction.cli \
 
 ## Utility Scripts
 
-- `python scripts/fetch_method.py` – wrapper around the main CLI. Run with `--help` to see available options; all arguments are forwarded as-is.
+- `python scripts/fetch_method.py` – fetches units and categories from method.gg. Run with `--help` to see available options; arguments mirror the CLI.
 
 ## Logging
 

--- a/scripts/fetch_method.py
+++ b/scripts/fetch_method.py
@@ -1,7 +1,7 @@
 """Wrapper for the ``wcr_data_extraction`` CLI.
 
-This script provides a stable entry point for fetching unit data. All command
-line arguments are passed directly to :mod:`wcr_data_extraction.cli`.
+This script provides a stable entry point for fetching unit and category data.
+All command line arguments are passed directly to :mod:`wcr_data_extraction.cli`.
 """
 
 import argparse
@@ -12,6 +12,13 @@ from typing import List
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
 from wcr_data_extraction import cli  # noqa: E402
+from wcr_data_extraction.fetcher import (  # noqa: E402
+    fetch_units,
+    fetch_categories,
+    configure_structlog,
+    FetchError,
+    logger,
+)
 
 
 def main(argv: List[str] | None = None) -> None:
@@ -25,8 +32,22 @@ def main(argv: List[str] | None = None) -> None:
     args, rest = parser.parse_known_args(argv)
     if args.help:
         cli.main(["--help"])
-    else:
-        cli.main(rest)
+        return
+
+    parsed = cli.parse_args(rest)
+    configure_structlog(parsed.log_level, Path(parsed.log_file))
+    try:
+        logger.info("Starting fetch")
+        fetch_categories(out_path=Path(parsed.categories), timeout=parsed.timeout)
+        fetch_units(
+            out_path=Path(parsed.output),
+            categories_path=Path(parsed.categories),
+            timeout=parsed.timeout,
+            max_workers=parsed.workers,
+        )
+    except FetchError as exc:
+        logger.error("Fehler beim Abrufen: %s", exc)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/src/wcr_data_extraction/__init__.py
+++ b/src/wcr_data_extraction/__init__.py
@@ -2,6 +2,7 @@
 
 from .fetcher import (
     fetch_units,
+    fetch_categories,
     load_categories,
     load_existing_units,
     is_unit_changed,
@@ -12,6 +13,7 @@ from .fetcher import (
 
 __all__ = [
     "fetch_units",
+    "fetch_categories",
     "load_categories",
     "load_existing_units",
     "is_unit_changed",

--- a/src/wcr_data_extraction/fetcher.py
+++ b/src/wcr_data_extraction/fetcher.py
@@ -162,6 +162,109 @@ def is_unit_changed(old: dict, new: dict) -> bool:
     return any(old.get(k) != new.get(k) for k in compare_keys)
 
 
+def fetch_categories(
+    *,
+    out_path: Path | str | None = None,
+    timeout: int = 10,
+    session: requests.Session | None = None,
+) -> None:
+    """Download category data from method.gg and store it as JSON."""
+
+    if not BASE_URL.startswith("https://"):
+        raise FetchError("BASE_URL must use HTTPS")
+
+    out_path = Path(out_path or CATEGORIES_PATH)
+
+    created_session = False
+    if session is None:
+        sess = create_session()
+        created_session = True
+    else:
+        sess = session
+
+    try:
+        logger.info("Fetching categories from %s", BASE_URL)
+        try:
+            response = sess.get(
+                BASE_URL, headers={"User-Agent": "Mozilla/5.0"}, timeout=timeout
+            )
+        except requests.RequestException as exc:
+            raise FetchError(f"Error fetching {BASE_URL}: {exc}") from exc
+        if response.status_code != 200:
+            raise FetchError(
+                f"Error fetching {BASE_URL}: Status {response.status_code}"
+            )
+
+        soup = BeautifulSoup(response.text, "html.parser")
+
+        minis = soup.select("div.mini-wrapper")
+        factions_raw = set()
+        speeds_raw = set()
+        for mini in minis:
+            fam = mini.get("data-family")
+            if fam:
+                factions_raw.add(fam.strip())
+            spd = mini.get("data-speed")
+            if spd and spd not in ("", "Znull"):
+                speeds_raw.add(spd.strip())
+
+        types_raw = {
+            inp.get("data-value", "").strip()
+            for inp in soup.select(".filter__type input[data-for='type']")
+            if inp.get("data-value")
+        }
+        traits_raw = {
+            inp.get("data-value", "").strip()
+            for inp in soup.select(".filter__trait input[data-for='traits']")
+            if inp.get("data-value")
+        }
+
+        existing: dict = {}
+        if out_path.exists():
+            try:
+                with open(out_path, encoding="utf-8") as f:
+                    existing = json.load(f)
+            except (json.JSONDecodeError, OSError) as exc:
+                logger.warning("Could not read categories from %s: %s", out_path, exc)
+
+        def build_items(name: str, values: set[str]) -> list[dict]:
+            items: list[dict] = []
+            existing_map = {item.get("id"): item for item in existing.get(name, [])}
+            for val in sorted(values):
+                parts = [p.strip() for p in val.split(",")]
+                cat_id = "-".join(p.lower() for p in parts)
+                en_name = " & ".join(parts)
+                item = existing_map.get(cat_id, {"id": cat_id, "names": {}})
+                names = item.get("names", {})
+                names["en"] = en_name
+                item["names"] = names
+                items.append(item)
+            return items
+
+        data = {
+            "factions": build_items("factions", factions_raw),
+            "types": build_items("types", types_raw),
+            "traits": build_items("traits", traits_raw),
+            "speeds": build_items("speeds", speeds_raw),
+        }
+
+        total = sum(len(v) for v in data.values())
+        if total == 0:
+            raise FetchError("No categories found")
+
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = out_path.with_suffix(".tmp")
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, ensure_ascii=False)
+            f.write("\n")
+        tmp_path.replace(out_path)
+
+        logger.info("%s categories saved to %s", total, out_path)
+    finally:
+        if created_session:
+            sess.close()
+
+
 def fetch_unit_details(
     url: str,
     categories: dict,
@@ -441,6 +544,9 @@ def fetch_units(
         for uid, old_unit in existing_units.items():
             if uid not in seen:
                 result_units.append(old_unit)
+
+        if not result_units:
+            raise FetchError("No units found")
 
         out_path.parent.mkdir(parents=True, exist_ok=True)
         tmp_path = out_path.with_suffix(".tmp")

--- a/tests/test_fetch_categories.py
+++ b/tests/test_fetch_categories.py
@@ -1,0 +1,84 @@
+import json
+from unittest.mock import Mock, patch
+
+import requests
+
+import pytest
+
+from wcr_data_extraction import fetcher
+
+
+def make_html():
+    return """
+    <div class='mini-wrapper' data-family='Alliance' data-speed='Slow'></div>
+    <div class='mini-wrapper' data-family='Alliance,Undead' data-speed='Fast'></div>
+    <div class='filter__type'>
+        <input data-for='type' data-value='Leader'/>
+        <input data-for='type' data-value='Spell'/>
+    </div>
+    <div class='filter__trait'>
+        <input data-for='traits' data-value='Ambush'/>
+        <input data-for='traits' data-value='AoE'/>
+    </div>
+    """
+
+
+def test_fetch_categories_writes_json(tmp_path):
+    html = make_html()
+    mock_response = Mock(status_code=200, text=html)
+    mock_session = Mock()
+    mock_session.get.return_value = mock_response
+    with patch.object(fetcher, "create_session", return_value=mock_session):
+        out_file = tmp_path / "cats.json"
+        with patch.object(fetcher, "CATEGORIES_PATH", out_file):
+            fetcher.fetch_categories(session=mock_session)
+    data = json.loads(out_file.read_text())
+    faction_ids = {f["id"] for f in data["factions"]}
+    assert "alliance" in faction_ids
+    assert "alliance-undead" in faction_ids
+    type_ids = {t["id"] for t in data["types"]}
+    assert type_ids == {"leader", "spell"}
+    trait_ids = {t["id"] for t in data["traits"]}
+    assert trait_ids == {"ambush", "aoe"}
+    speed_ids = {s["id"] for s in data["speeds"]}
+    assert speed_ids == {"slow", "fast"}
+
+
+def test_fetch_categories_preserves_translations(tmp_path):
+    html = make_html()
+    mock_response = Mock(status_code=200, text=html)
+    mock_session = Mock()
+    mock_session.get.return_value = mock_response
+    existing = {
+        "factions": [{"id": "alliance", "names": {"en": "Alliance", "de": "Allianz"}}],
+        "types": [],
+        "traits": [],
+        "speeds": [],
+    }
+    out_file = tmp_path / "cats.json"
+    out_file.write_text(json.dumps(existing))
+    with patch.object(fetcher, "create_session", return_value=mock_session):
+        with patch.object(fetcher, "CATEGORIES_PATH", out_file):
+            fetcher.fetch_categories(session=mock_session)
+    data = json.loads(out_file.read_text())
+    alliance = next(x for x in data["factions"] if x["id"] == "alliance")
+    assert alliance["names"]["de"] == "Allianz"
+
+
+def test_fetch_categories_request_exception(tmp_path):
+    mock_session = Mock()
+    mock_session.get.side_effect = requests.RequestException("boom")
+    with patch.object(fetcher, "create_session", return_value=mock_session):
+        with patch.object(fetcher, "CATEGORIES_PATH", tmp_path / "c.json"):
+            with pytest.raises(fetcher.FetchError):
+                fetcher.fetch_categories(session=mock_session)
+
+
+def test_fetch_categories_http_error(tmp_path):
+    mock_response = Mock(status_code=500, text="")
+    mock_session = Mock()
+    mock_session.get.return_value = mock_response
+    with patch.object(fetcher, "create_session", return_value=mock_session):
+        with patch.object(fetcher, "CATEGORIES_PATH", tmp_path / "c.json"):
+            with pytest.raises(fetcher.FetchError):
+                fetcher.fetch_categories(session=mock_session)

--- a/tests/test_fetch_script.py
+++ b/tests/test_fetch_script.py
@@ -1,0 +1,31 @@
+import sys
+from pathlib import Path
+from argparse import Namespace
+from unittest.mock import patch
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from scripts import fetch_method  # noqa: E402
+
+
+def test_script_invokes_fetchers(tmp_path):
+    args = Namespace(
+        output=str(tmp_path / "u.json"),
+        categories=str(tmp_path / "c.json"),
+        timeout=5,
+        workers=2,
+        log_level="INFO",
+        log_file=str(tmp_path / "log.json"),
+    )
+    with patch.object(fetch_method.cli, "parse_args", return_value=args):
+        with patch.object(fetch_method, "configure_structlog") as conf, patch.object(
+            fetch_method, "fetch_categories"
+        ) as fc, patch.object(fetch_method, "fetch_units") as fu:
+            fetch_method.main([])
+            conf.assert_called_once_with("INFO", Path(args.log_file))
+            fc.assert_called_once_with(out_path=Path(args.categories), timeout=5)
+            fu.assert_called_once_with(
+                out_path=Path(args.output),
+                categories_path=Path(args.categories),
+                timeout=5,
+                max_workers=2,
+            )

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,5 +1,7 @@
 from unittest.mock import Mock, patch
 
+import pytest
+
 from wcr_data_extraction import fetcher
 
 
@@ -23,5 +25,17 @@ def test_fetch_units_closes_created_session(tmp_path):
         ), patch.object(
             fetcher, "fetch_unit_details", return_value={}
         ):
-            fetcher.fetch_units()
+            with pytest.raises(fetcher.FetchError):
+                fetcher.fetch_units()
+    mock_session.close.assert_called_once()
+
+
+def test_fetch_categories_closes_created_session(tmp_path):
+    mock_session = Mock()
+    mock_session.get.return_value.status_code = 200
+    mock_session.get.return_value.text = "<div></div>"
+    with patch.object(fetcher, "create_session", return_value=mock_session):
+        with patch.object(fetcher, "CATEGORIES_PATH", tmp_path / "c.json"):
+            with pytest.raises(fetcher.FetchError):
+                fetcher.fetch_categories()
     mock_session.close.assert_called_once()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -30,7 +30,7 @@ def test_fetch_units_closes_created_session(tmp_path):
     mock_session.close.assert_called_once()
 
 
-def test_fetch_categories_closes_created_session(tmp_path):
+def test_fetch_categories_closes_session(tmp_path):
     mock_session = Mock()
     mock_session.get.return_value.status_code = 200
     mock_session.get.return_value.text = "<div></div>"


### PR DESCRIPTION
## Summary
- fetch categories from method.gg with new `fetch_categories`
- run category fetching in `scripts/fetch_method.py`
- export new helper in package
- document script behavior
- cover new code with tests
- raise errors when scrape result is empty

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e97b87eb8832fac966c932990efe4