### PR TITLE
Add change detection for Method.gg fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - `scripts/fetch_method.py` now exposes a `main()` function.
 - Command-line interface for `fetch_method.py` with `--output`, `--categories` and `--timeout` options.
 - New unit tests for CLI parsing.
+- `scripts/fetch_method.py` now runs without CLI flags and only overwrites files
+  in `tmp_data/` when the fetched data changed.
 - Development requirements file and optional `--dev` flag for `setup.sh`.
 - Automatic fetching of category data to `categories.json`.
 - Section in README on updating dependencies.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ python -m wcr_data_extraction.cli \
 
 ## Utility Scripts
 
-- `python scripts/fetch_method.py` – fetches units and categories from method.gg. Run with `--help` to see available options; arguments mirror the CLI.
+- `python scripts/fetch_method.py` – downloads the latest unit and category data
+  from method.gg into `tmp_data/`. Existing files are only overwritten when the
+  fetched content has changed.
 
 ## Logging
 

--- a/tests/test_fetch_script.py
+++ b/tests/test_fetch_script.py
@@ -1,31 +1,24 @@
 import sys
 from pathlib import Path
-from argparse import Namespace
 from unittest.mock import patch
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from scripts import fetch_method  # noqa: E402
 
 
-def test_script_invokes_fetchers(tmp_path):
-    args = Namespace(
-        output=str(tmp_path / "u.json"),
-        categories=str(tmp_path / "c.json"),
-        timeout=5,
-        workers=2,
-        log_level="INFO",
-        log_file=str(tmp_path / "log.json"),
-    )
-    with patch.object(fetch_method.cli, "parse_args", return_value=args):
-        with patch.object(fetch_method, "configure_structlog") as conf, patch.object(
-            fetch_method, "fetch_categories"
-        ) as fc, patch.object(fetch_method, "fetch_units") as fu:
-            fetch_method.main([])
-            conf.assert_called_once_with("INFO", Path(args.log_file))
-            fc.assert_called_once_with(out_path=Path(args.categories), timeout=5)
-            fu.assert_called_once_with(
-                out_path=Path(args.output),
-                categories_path=Path(args.categories),
-                timeout=5,
-                max_workers=2,
-            )
+def test_script_invokes_fetchers():
+    base = Path(fetch_method.__file__).resolve().parents[1]
+    units = base / "tmp_data" / "units.json"
+    cats = base / "tmp_data" / "categories.json"
+    with patch.object(fetch_method, "configure_structlog") as conf, patch.object(
+        fetch_method, "fetch_categories"
+    ) as fc, patch.object(fetch_method, "fetch_units") as fu:
+        fetch_method.main()
+        conf.assert_called_once_with("INFO")
+        fc.assert_called_once_with(out_path=cats, timeout=10)
+        fu.assert_called_once_with(
+            out_path=units,
+            categories_path=cats,
+            timeout=10,
+            max_workers=4,
+        )


### PR DESCRIPTION
## Summary
- update fetch utilities to skip writing unchanged data
- refactor `scripts/fetch_method.py` to fetch to `tmp_data/` without CLI flags
- document new script behaviour in README
- log skipped updates in CHANGELOG
- test new skip logic for categories and units

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eaa1d9e4c832f9f06bf976e2d702a