### PR TITLE
Add default tmp_data paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 
 ### Changed
 - `scripts/fetch_method.py` now skips writing `units.json` and `categories.json` when no changes are detected.
+- `scripts/fetch_method.py` defaults to `tmp_data/` for units and categories.
 - Removed tracked `data/` directory and added it to `.gitignore`.
 - GitHub Actions workflow uses explicit paths when updating data.
 - Pinned package versions in `requirements.txt` and `requirements-dev.txt`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Warcraft Rumble Data Extractor
 
-Simple scraper that downloads minis and category data from [method.gg](https://www.method.gg/warcraft-rumble/minis). Results are written to `data/units.json` and `data/categories.json`, both ignored by Git.
+Simple scraper that downloads minis and category data from [method.gg](https://www.method.gg/warcraft-rumble/minis). Results are written to `tmp_data/units.json` and `tmp_data/categories.json` by default, both ignored by Git.
 
 ## Setup
 
@@ -22,8 +22,8 @@ logs. Leave them empty if you do not use those features.
 
 ```bash
 python -m wcr_data_extraction.cli \
-  --output data/units.json \
-  --categories data/categories.json \
+  --output tmp_data/units.json \
+  --categories tmp_data/categories.json \
   --timeout 10 \
   --workers 4 \
   --log-level INFO \
@@ -65,7 +65,7 @@ Coverage must remain above 90 %.
 Deploy the extractor to [Railway](https://railway.app/). Set the start command to run the CLI, for example:
 
 ```bash
-python -m wcr_data_extraction.cli --output data/units.json --categories data/categories.json
+python -m wcr_data_extraction.cli --output tmp_data/units.json --categories tmp_data/categories.json
 ```
 
 The `railway_logs` workflow streams service logs with
@@ -74,7 +74,7 @@ and uploads them as artifacts.
 
 ## Contributing translations
 
-Names and trait descriptions are defined in your local `data/categories.json`. Add new language keys in the `names` or `descriptions` objects, keeping the English text intact. Running `scripts/fetch_method.py` preserves existing translations in `units.json`.
+Names and trait descriptions are defined in your local `tmp_data/categories.json`. Add new language keys in the `names` or `descriptions` objects, keeping the English text intact. Running `scripts/fetch_method.py` preserves existing translations in `units.json`.
 The script compares downloaded data with the current files and only writes an update when changes are detected.
 
 ## License

--- a/scripts/fetch_method.py
+++ b/scripts/fetch_method.py
@@ -13,12 +13,18 @@ from typing import List
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
 from wcr_data_extraction import cli  # noqa: E402
+from wcr_data_extraction import fetcher  # noqa: E402
 from wcr_data_extraction.fetcher import (  # noqa: E402
     fetch_units,
     fetch_categories,
     configure_structlog,
     FetchError,
     logger,
+)
+
+DEFAULT_UNITS_PATH = Path(__file__).resolve().parents[1] / "tmp_data" / "units.json"
+DEFAULT_CATEGORIES_PATH = (
+    Path(__file__).resolve().parents[1] / "tmp_data" / "categories.json"
 )
 
 
@@ -52,6 +58,10 @@ def main(argv: List[str] | None = None) -> None:
         cli.main(["--help"])
         return
 
+    cli.OUT_PATH = DEFAULT_UNITS_PATH
+    cli.CATEGORIES_PATH = DEFAULT_CATEGORIES_PATH
+    fetcher.OUT_PATH = DEFAULT_UNITS_PATH
+    fetcher.CATEGORIES_PATH = DEFAULT_CATEGORIES_PATH
     parsed = cli.parse_args(rest)
     configure_structlog(parsed.log_level, Path(parsed.log_file))
     logger.info("Starting fetch")


### PR DESCRIPTION
## Summary
- default to tmp_data paths in fetch script
- document updated defaults and update changelog

## Testing
- `pre-commit run --files CHANGELOG.md README.md scripts/fetch_method.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ec2dc43f0832fb21fb4ce112fd163