### PR TITLE
Fix CI requirement install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
           key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Install dependencies
         run: |
-          pip install -r requirements.txt
-          pip install -r requirements-dev.txt
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
       - name: Install Railway CLI
         run: npx railway --version
       - name: Prepare logs directory


### PR DESCRIPTION
## Summary
- avoid CI failures if requirement files are missing

## Testing
- `pre-commit run --all-files --show-diff-on-failure --color=always`
- `pytest --cov=. --cov-report=xml --cov-report=term`

------
https://chatgpt.com/codex/tasks/task_e_685ed0d08bc4832f91aa7c20ca4403c8