### PR TITLE
Implement dynamic category aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,3 +68,4 @@
 - Security workflow runs CodeQL and TruffleHog scans.
 - Dependabot auto-merge workflow.
 - GitHub Actions workflow to auto-publish `units.json` and `categories.json` into `data/` if changed
+- `fetch_categories` derives `types`, `traits` and `speeds` from `units.json` instead of HTML filters.

--- a/scripts/fetch_method.py
+++ b/scripts/fetch_method.py
@@ -71,28 +71,6 @@ def main(argv: List[str] | None = None) -> None:
     cats_path = Path(parsed.categories)
     units_path = Path(parsed.output)
 
-    cats_tmp = cats_path.with_suffix(".tmp")
-    try:
-        fetch_categories(
-            out_path=cats_tmp,
-            timeout=parsed.timeout,
-            existing_path=cats_path,
-        )
-        new_cats = _load_json(cats_tmp) or {}
-        logger.info("%s category items fetched", sum(len(v) for v in new_cats.values()))
-    except FetchError as exc:
-        logger.warning("Fetching categories failed: %s", exc)
-        cats_tmp.unlink(missing_ok=True)
-        return
-
-    existing_cats = _load_json(cats_path) or {}
-    if _dump_sorted(existing_cats) == _dump_sorted(new_cats):
-        logger.info("No changes detected for categories")
-        cats_tmp.unlink(missing_ok=True)
-    else:
-        cats_tmp.replace(cats_path)
-        logger.info("Categories updated at %s", cats_path)
-
     units_tmp = units_path.with_suffix(".tmp")
     try:
         fetch_units(
@@ -116,6 +94,29 @@ def main(argv: List[str] | None = None) -> None:
     else:
         units_tmp.replace(units_path)
         logger.info("Units updated at %s", units_path)
+
+    cats_tmp = cats_path.with_suffix(".tmp")
+    try:
+        fetch_categories(
+            out_path=cats_tmp,
+            timeout=parsed.timeout,
+            existing_path=cats_path,
+            units_path=units_path,
+        )
+        new_cats = _load_json(cats_tmp) or {}
+        logger.info("%s category items fetched", sum(len(v) for v in new_cats.values()))
+    except FetchError as exc:
+        logger.warning("Fetching categories failed: %s", exc)
+        cats_tmp.unlink(missing_ok=True)
+        return
+
+    existing_cats = _load_json(cats_path) or {}
+    if _dump_sorted(existing_cats) == _dump_sorted(new_cats):
+        logger.info("No changes detected for categories")
+        cats_tmp.unlink(missing_ok=True)
+    else:
+        cats_tmp.replace(cats_path)
+        logger.info("Categories updated at %s", cats_path)
 
 
 if __name__ == "__main__":

--- a/tests/test_fetch_categories.py
+++ b/tests/test_fetch_categories.py
@@ -2,50 +2,73 @@ import json
 from unittest.mock import Mock, patch
 
 import requests
-
 import pytest
 
 from wcr_data_extraction import fetcher
 
 
-def make_html():
+def make_html() -> str:
     return """
     <div class='mini-wrapper' data-family='Alliance' data-speed='Slow'></div>
     <div class='mini-wrapper' data-family='Alliance,Undead' data-speed='Fast'></div>
-    <div class='filter__type'>
-        <input data-for='type' data-value='Leader'/>
-        <input data-for='type' data-value='Spell'/>
-    </div>
-    <div class='filter__trait'>
-        <input data-for='traits' data-value='Ambush'/>
-        <input data-for='traits' data-value='AoE'/>
-    </div>
     """
+
+
+def make_units() -> list[dict]:
+    return [
+        {
+            "id": "leader-unit",
+            "names": {"en": "Leader Unit"},
+            "faction_ids": ["alliance"],
+            "type_id": "leader",
+            "speed_id": "slow",
+            "trait_ids": ["ambush"],
+            "details": {},
+        },
+        {
+            "id": "spell-unit",
+            "names": {"en": "Spell Unit"},
+            "faction_ids": ["alliance", "undead"],
+            "type_id": "spell",
+            "speed_id": "fast",
+            "trait_ids": ["aoe"],
+            "details": {},
+        },
+    ]
 
 
 def test_fetch_categories_writes_json(tmp_path):
     html = make_html()
+    units_path = tmp_path / "units.json"
+    units_path.write_text(json.dumps(make_units()))
+
     mock_response = Mock(status_code=200, text=html)
     mock_session = Mock()
     mock_session.get.return_value = mock_response
     with patch.object(fetcher, "create_session", return_value=mock_session):
         out_file = tmp_path / "cats.json"
-        with patch.object(fetcher, "CATEGORIES_PATH", out_file):
+        with patch.object(fetcher, "CATEGORIES_PATH", out_file), patch.object(
+            fetcher,
+            "OUT_PATH",
+            units_path,
+        ):
             fetcher.fetch_categories(session=mock_session)
     data = json.loads(out_file.read_text())
     faction_ids = {f["id"] for f in data["factions"]}
-    assert "alliance" in faction_ids
-    assert "alliance-undead" in faction_ids
+    assert {"alliance", "alliance-undead"} <= faction_ids
     type_ids = {t["id"] for t in data["types"]}
     assert type_ids == {"leader", "spell"}
     trait_ids = {t["id"] for t in data["traits"]}
     assert trait_ids == {"ambush", "aoe"}
     speed_ids = {s["id"] for s in data["speeds"]}
-    assert speed_ids == {"slow", "fast"}
+    assert {"slow", "fast"} <= speed_ids
 
 
 def test_fetch_categories_preserves_translations(tmp_path):
     html = make_html()
+    units_path = tmp_path / "units.json"
+    units_path.write_text(json.dumps(make_units()))
+
     mock_response = Mock(status_code=200, text=html)
     mock_session = Mock()
     mock_session.get.return_value = mock_response
@@ -58,7 +81,11 @@ def test_fetch_categories_preserves_translations(tmp_path):
     out_file = tmp_path / "cats.json"
     out_file.write_text(json.dumps(existing))
     with patch.object(fetcher, "create_session", return_value=mock_session):
-        with patch.object(fetcher, "CATEGORIES_PATH", out_file):
+        with patch.object(fetcher, "CATEGORIES_PATH", out_file), patch.object(
+            fetcher,
+            "OUT_PATH",
+            units_path,
+        ):
             fetcher.fetch_categories(session=mock_session)
     data = json.loads(out_file.read_text())
     alliance = next(x for x in data["factions"] if x["id"] == "alliance")
@@ -69,7 +96,13 @@ def test_fetch_categories_request_exception(tmp_path):
     mock_session = Mock()
     mock_session.get.side_effect = requests.RequestException("boom")
     with patch.object(fetcher, "create_session", return_value=mock_session):
-        with patch.object(fetcher, "CATEGORIES_PATH", tmp_path / "c.json"):
+        with patch.object(
+            fetcher, "CATEGORIES_PATH", tmp_path / "c.json"
+        ), patch.object(
+            fetcher,
+            "OUT_PATH",
+            tmp_path / "units.json",
+        ):
             with pytest.raises(fetcher.FetchError):
                 fetcher.fetch_categories(session=mock_session)
 
@@ -79,6 +112,12 @@ def test_fetch_categories_http_error(tmp_path):
     mock_session = Mock()
     mock_session.get.return_value = mock_response
     with patch.object(fetcher, "create_session", return_value=mock_session):
-        with patch.object(fetcher, "CATEGORIES_PATH", tmp_path / "c.json"):
+        with patch.object(
+            fetcher, "CATEGORIES_PATH", tmp_path / "c.json"
+        ), patch.object(
+            fetcher,
+            "OUT_PATH",
+            tmp_path / "units.json",
+        ):
             with pytest.raises(fetcher.FetchError):
                 fetcher.fetch_categories(session=mock_session)

--- a/tests/test_fetch_script.py
+++ b/tests/test_fetch_script.py
@@ -18,16 +18,11 @@ def test_script_invokes_fetchers(tmp_path):
     )
     with patch.object(fetch_method.cli, "parse_args", return_value=args):
         with patch.object(fetch_method, "configure_structlog") as conf, patch.object(
-            fetch_method, "fetch_categories"
-        ) as fc, patch.object(fetch_method, "fetch_units") as fu:
+            fetch_method,
+            "fetch_units",
+        ) as fu, patch.object(fetch_method, "fetch_categories") as fc:
             fetch_method.main([])
             conf.assert_called_once_with("INFO", Path(args.log_file))
-            cat_tmp = Path(args.categories).with_suffix(".tmp")
-            fc.assert_called_once_with(
-                out_path=cat_tmp,
-                timeout=5,
-                existing_path=Path(args.categories),
-            )
             unit_tmp = Path(args.output).with_suffix(".tmp")
             fu.assert_called_once_with(
                 out_path=unit_tmp,
@@ -35,6 +30,13 @@ def test_script_invokes_fetchers(tmp_path):
                 timeout=5,
                 max_workers=2,
                 existing_path=Path(args.output),
+            )
+            cat_tmp = Path(args.categories).with_suffix(".tmp")
+            fc.assert_called_once_with(
+                out_path=cat_tmp,
+                timeout=5,
+                existing_path=Path(args.categories),
+                units_path=Path(args.output),
             )
 
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -32,6 +32,12 @@ def test_fetch_categories_closes_created_session(tmp_path):
     mock_session.get.return_value.status_code = 200
     mock_session.get.return_value.text = "<div></div>"
     with patch.object(fetcher, "create_session", return_value=mock_session):
-        with patch.object(fetcher, "CATEGORIES_PATH", tmp_path / "c.json"):
+        with patch.object(
+            fetcher, "CATEGORIES_PATH", tmp_path / "c.json"
+        ), patch.object(
+            fetcher,
+            "OUT_PATH",
+            tmp_path / "units.json",
+        ):
             fetcher.fetch_categories()
     mock_session.close.assert_called_once()


### PR DESCRIPTION
## Summary
- derive category types and traits from units.json
- keep name translations when regenerating categories
- update CLI script and tests for new parameter
- document change in CHANGELOG
- ensure categories use newly fetched units during fetch script

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685efbde8454832f8b7a7e6cfae5ea07