### PR TITLE
Fix category export on first run

### DIFF
--- a/scripts/fetch_method.py
+++ b/scripts/fetch_method.py
@@ -71,29 +71,6 @@ def main(argv: List[str] | None = None) -> None:
     cats_path = Path(parsed.categories)
     units_path = Path(parsed.output)
 
-    cats_tmp = cats_path.with_suffix(".tmp")
-    try:
-        fetch_categories(
-            out_path=cats_tmp,
-            timeout=parsed.timeout,
-            existing_path=cats_path,
-            units_path=units_path,
-        )
-        new_cats = _load_json(cats_tmp) or {}
-        logger.info("%s category items fetched", sum(len(v) for v in new_cats.values()))
-    except FetchError as exc:
-        logger.warning("Fetching categories failed: %s", exc)
-        cats_tmp.unlink(missing_ok=True)
-        return
-
-    existing_cats = _load_json(cats_path) or {}
-    if _dump_sorted(existing_cats) == _dump_sorted(new_cats):
-        logger.info("No changes detected for categories")
-        cats_tmp.unlink(missing_ok=True)
-    else:
-        cats_tmp.replace(cats_path)
-        logger.info("Categories updated at %s", cats_path)
-
     units_tmp = units_path.with_suffix(".tmp")
     try:
         fetch_units(
@@ -117,6 +94,29 @@ def main(argv: List[str] | None = None) -> None:
     else:
         units_tmp.replace(units_path)
         logger.info("Units updated at %s", units_path)
+
+    cats_tmp = cats_path.with_suffix(".tmp")
+    try:
+        fetch_categories(
+            out_path=cats_tmp,
+            timeout=parsed.timeout,
+            existing_path=cats_path,
+            units_path=units_path,
+        )
+        new_cats = _load_json(cats_tmp) or {}
+        logger.info("%s category items fetched", sum(len(v) for v in new_cats.values()))
+    except FetchError as exc:
+        logger.warning("Fetching categories failed: %s", exc)
+        cats_tmp.unlink(missing_ok=True)
+        return
+
+    existing_cats = _load_json(cats_path) or {}
+    if _dump_sorted(existing_cats) == _dump_sorted(new_cats):
+        logger.info("No changes detected for categories")
+        cats_tmp.unlink(missing_ok=True)
+    else:
+        cats_tmp.replace(cats_path)
+        logger.info("Categories updated at %s", cats_path)
 
 
 if __name__ == "__main__":

--- a/tests/test_fetch_script.py
+++ b/tests/test_fetch_script.py
@@ -22,13 +22,6 @@ def test_script_invokes_fetchers(tmp_path):
         ) as fc, patch.object(fetch_method, "fetch_units") as fu:
             fetch_method.main([])
             conf.assert_called_once_with("INFO", Path(args.log_file))
-            cat_tmp = Path(args.categories).with_suffix(".tmp")
-            fc.assert_called_once_with(
-                out_path=cat_tmp,
-                timeout=5,
-                existing_path=Path(args.categories),
-                units_path=Path(args.output),
-            )
             unit_tmp = Path(args.output).with_suffix(".tmp")
             fu.assert_called_once_with(
                 out_path=unit_tmp,
@@ -36,6 +29,13 @@ def test_script_invokes_fetchers(tmp_path):
                 timeout=5,
                 max_workers=2,
                 existing_path=Path(args.output),
+            )
+            cat_tmp = Path(args.categories).with_suffix(".tmp")
+            fc.assert_called_once_with(
+                out_path=cat_tmp,
+                timeout=5,
+                existing_path=Path(args.categories),
+                units_path=Path(args.output),
             )
 
 


### PR DESCRIPTION
## Summary
- ensure units are fetched before categories
- update tests for new fetch order

## Testing
- `pre-commit run --all-files`
- `pytest --cov=.`

------
https://chatgpt.com/codex/tasks/task_e_685f111eab58832f9cdcf9d605f61507