### PR TITLE
Fix CLI to fetch categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,3 +69,4 @@
 - Dependabot auto-merge workflow.
 - GitHub Actions workflow to auto-publish `units.json` and `categories.json` into `data/` if changed
 - `fetch_categories` derives `types`, `traits` and `speeds` from `units.json` instead of HTML filters.
+- CLI now writes `categories.json` alongside `units.json`.

--- a/src/wcr_data_extraction/cli.py
+++ b/src/wcr_data_extraction/cli.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from .fetcher import (
     fetch_units,
+    fetch_categories,
     OUT_PATH,
     CATEGORIES_PATH,
     FetchError,
@@ -59,6 +60,12 @@ def main(argv: list[str] | None = None) -> None:
             categories_path=Path(args.categories),
             timeout=args.timeout,
             max_workers=args.workers,
+        )
+        fetch_categories(
+            out_path=Path(args.categories),
+            timeout=args.timeout,
+            existing_path=Path(args.categories),
+            units_path=Path(args.output),
         )
     except FetchError as exc:
         logger.error("Fehler beim Abrufen: %s", exc)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,7 +19,7 @@ def test_parse_args_defaults(tmp_path):
         assert Path(args.log_file).name.startswith("runtime-")
 
 
-def test_main_invokes_fetch_units(tmp_path):
+def test_main_invokes_fetchers(tmp_path):
     args = [
         "--output",
         str(tmp_path / "u.json"),
@@ -31,17 +31,24 @@ def test_main_invokes_fetch_units(tmp_path):
         "DEBUG",
     ]
     with patch.object(cli, "configure_structlog") as mock_conf, patch.object(
-        cli, "fetch_units"
-    ) as mock_fetch:
+        cli,
+        "fetch_units",
+    ) as mock_units, patch.object(cli, "fetch_categories") as mock_cats:
         cli.main(args)
         called_path = mock_conf.call_args.args[1]
         assert called_path.parent == Path("logs")
         assert called_path.name.startswith("runtime-")
-        mock_fetch.assert_called_once_with(
+        mock_units.assert_called_once_with(
             out_path=Path(args[1]),
             categories_path=Path(args[3]),
             timeout=7,
             max_workers=1,
+        )
+        mock_cats.assert_called_once_with(
+            out_path=Path(args[3]),
+            timeout=7,
+            existing_path=Path(args[3]),
+            units_path=Path(args[1]),
         )
 
 


### PR DESCRIPTION
## Summary
- call `fetch_categories()` in the CLI after fetching units
- adjust test to expect the new behaviour
- document the change in `CHANGELOG`

## Testing
- `pre-commit run --files src/wcr_data_extraction/cli.py tests/test_cli.py CHANGELOG.md`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685f1a3b0c64832f9ac733e1c1daeeac