### PR TITLE
Update data workflow

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -20,16 +20,18 @@ jobs:
         run: pip install -r requirements.txt
       - name: Fetch latest data
         run: |
-          python scripts/fetch_method.py \
-            --output data/units.json \
-            --categories data/categories.json \
-            --timeout 10
+          python scripts/fetch_method.py --timeout 10
       - name: Commit changes
         run: |
-          if [[ `git status --porcelain data/units.json` ]]; then
+          if [[ $(git status --porcelain data/export/units.json data/export/categories.json) ]]; then
             git config user.name 'github-actions[bot]'
             git config user.email 'github-actions[bot]@users.noreply.github.com'
-            git add data/units.json
-            git commit -m 'Update units.json via workflow'
+            git add data/export/units.json data/export/categories.json
+            git commit -m 'Update data via workflow'
             git push
           fi
+      - name: Upload logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: extractor-logs
+          path: logs/runtime-*.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,3 +70,4 @@
 - GitHub Actions workflow to auto-publish `units.json` and `categories.json` into `data/` if changed
 - `fetch_categories` derives `types`, `traits` and `speeds` from `units.json` instead of HTML filters.
 - CLI now writes `categories.json` alongside `units.json`.
+- Update workflow to use default export paths and upload extractor logs.


### PR DESCRIPTION
## Summary
- update workflow to run extractor with default paths
- commit both exported json files
- upload extractor logs
- note update in CHANGELOG

## Testing
- `pre-commit run --all-files`
- `pytest`
- `pytest tests/test_export_files.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685f25dc2a44832fbb4b9c402e3ec55c