### PR TITLE
Fix categories generation for trait descriptions

### DIFF
--- a/tests/test_fetch_method.py
+++ b/tests/test_fetch_method.py
@@ -409,6 +409,43 @@ def test_fetch_unit_details_returns_trait_ids():
     assert details["traits"] == ["tank"]
 
 
+def test_fetch_unit_details_trait_descriptions():
+    html = """
+        <div class=\"mini-section\">
+            <h2>Traits</h2>
+            <div class=\"mini-trait-tile\">
+                <div class=\"detail-info\">Brambles</div>
+                <div class=\"mini-talent__description\">Root foes for 3s</div>
+            </div>
+        </div>
+    """
+    mock_response = Mock(status_code=200, text=html)
+
+    mock_session = Mock()
+    mock_session.get.return_value = mock_response
+    with patch.object(fetcher, "create_session", return_value=mock_session), patch(
+        "wcr_data_extraction.fetcher.load_categories",
+        return_value={
+            "faction": {},
+            "type": {},
+            "trait": {"Brambles": "brambles"},
+            "speed": {},
+            "trait_desc": {},
+        },
+    ):
+        cats = fetcher.load_categories()
+        details = fetcher.fetch_unit_details(
+            "https://example.com/unit", cats, session=mock_session
+        )
+        mock_session.get.assert_called_once_with(
+            "https://example.com/unit",
+            headers={"User-Agent": "Mozilla/5.0"},
+            timeout=10,
+        )
+
+    assert details["trait_descriptions"] == {"brambles": "Root foes for 3s"}
+
+
 def test_fetch_unit_details_core_trait_ids():
     html = """
         <div class=\"mini-section\">


### PR DESCRIPTION
## Summary
- parse trait descriptions in `fetch_unit_details`
- preserve those descriptions when generating categories
- add unit and category tests for trait descriptions
- restore clean `categories.json`

## Testing
- `python -m pre_commit run --files src/wcr_data_extraction/fetcher.py tests/test_fetch_categories.py tests/test_fetch_method.py data/export/categories.json`
- `pytest --cov=.`

------
https://chatgpt.com/codex/tasks/task_e_685f31797648832f96dc8af646fe2dd3