### PR TITLE
Add CI badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,3 +71,4 @@
 - `fetch_categories` derives `types`, `traits` and `speeds` from `units.json` instead of HTML filters.
 - CLI now writes `categories.json` alongside `units.json`.
 - Update workflow to use default export paths and upload extractor logs.
+- README now displays a CI coverage badge.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Warcraft Rumble Data Extractor
 
+![coverage](https://github.com/Lotus-Gaming-DE/wcr-extractor/actions/workflows/ci.yml/badge.svg)
+
 Simple scraper that downloads minis and category data from [method.gg](https://www.method.gg/warcraft-rumble/minis). Results are written to `data/export/units.json` and `data/export/categories.json` by default, both ignored by Git except for these two files.
 
 ## Setup


### PR DESCRIPTION
## Summary
- show CI coverage badge in README
- record README badge addition in CHANGELOG

## Testing
- `pre-commit run --files README.md CHANGELOG.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ffef733a4832f81e14a35a262cd85