### PR TITLE
Update env var docs for API publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,3 +72,5 @@
 - CLI now writes `categories.json` alongside `units.json`.
 - Update workflow to use default export paths and upload extractor logs.
 - README now displays a CI coverage badge.
+- README clarifies that `API_REPO_TOKEN` must have push rights to `wcr-api` and
+  that the publish workflow fails without it.

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ Copy `.env.example` to `.env` if you need to define environment variables. None 
 
 `SNYK_TOKEN`, `RAILWAY_TOKEN`, `RAILWAY_PROJECT` and `RAILWAY_SERVICE` are used
 by the GitHub Actions workflows for security scanning and fetching Railway logs.
-`API_REPO_TOKEN` is required for publishing data to the external API repository.
-Leave them empty if you do not use those features.
+`API_REPO_TOKEN` must be a GitHub token with push rights to
+[`wcr-api`](https://github.com/Lotus-Gaming-DE/wcr-api); without it, the
+publish workflow will fail. Leave them empty if you do not use those features.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- expand `API_REPO_TOKEN` explanation in the README
- note failing workflow without the token
- document the clarification in the CHANGELOG

## Testing
- `pre-commit run --all-files`
- `pytest --cov=.`

------
https://chatgpt.com/codex/tasks/task_e_686002180ae4832fbc6ebad342ba0ec6