### PR TITLE
Handle missing trait descriptions

### DIFF
--- a/src/wcr_data_extraction/fetcher.py
+++ b/src/wcr_data_extraction/fetcher.py
@@ -229,7 +229,8 @@ def fetch_categories(
             for tid, desc in (
                 unit.get("details", {}).get("trait_descriptions", {}).items()
             ):
-                trait_descs.setdefault(tid, desc)
+                if desc:
+                    trait_descs[tid] = desc
             s_id = unit.get("speed_id")
             if s_id:
                 speed_ids.add(s_id)

--- a/tests/test_fetch_categories.py
+++ b/tests/test_fetch_categories.py
@@ -144,3 +144,27 @@ def test_fetch_categories_uses_trait_descriptions(tmp_path):
     data = json.loads(out_file.read_text())
     trait = next(t for t in data["traits"] if t["id"] == "ambush")
     assert trait["descriptions"]["en"] == "Ambush foes"
+
+
+def test_fetch_categories_prefers_non_null_descriptions(tmp_path):
+    html = make_html()
+    units_path = tmp_path / "units.json"
+    units = make_units()
+    units[0]["details"] = {"trait_descriptions": {"ambush": None}}
+    units[1]["details"] = {"trait_descriptions": {"ambush": "Ambush foes"}}
+    units_path.write_text(json.dumps(units))
+
+    mock_response = Mock(status_code=200, text=html)
+    mock_session = Mock()
+    mock_session.get.return_value = mock_response
+    with patch.object(fetcher, "create_session", return_value=mock_session):
+        out_file = tmp_path / "cats.json"
+        with patch.object(fetcher, "CATEGORIES_PATH", out_file), patch.object(
+            fetcher,
+            "OUT_PATH",
+            units_path,
+        ):
+            fetcher.fetch_categories(session=mock_session)
+    data = json.loads(out_file.read_text())
+    trait = next(t for t in data["traits"] if t["id"] == "ambush")
+    assert trait["descriptions"]["en"] == "Ambush foes"


### PR DESCRIPTION
## Summary
- keep the latest non-null trait description when generating categories
- test description handling for multiple units

## Testing
- `pre-commit run --files src/wcr_data_extraction/fetcher.py tests/test_fetch_categories.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860034c89c4832fb37216bd9cc9c785