### PR TITLE
Fix trait description merging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,3 +74,7 @@
 - README now displays a CI coverage badge.
 - README clarifies that `API_REPO_TOKEN` must have push rights to `wcr-api` and
   that the publish workflow fails without it.
+
+### Fixed
+- `fetch_unit_details` now stores trait descriptions when categories contain
+  `null` values.

--- a/src/wcr_data_extraction/fetcher.py
+++ b/src/wcr_data_extraction/fetcher.py
@@ -395,7 +395,10 @@ def fetch_unit_details(
                 trait_id = cat_map.get(name, name.lower().replace(" ", "-"))
                 traits.append(trait_id)
                 if desc:
-                    trait_desc_map[trait_id] = desc_map.get(trait_id, desc)
+                    existing_desc = desc_map.get(trait_id)
+                    trait_desc_map[trait_id] = (
+                        existing_desc if existing_desc is not None else desc
+                    )
     if traits:
         details["traits"] = traits
     if trait_desc_map:

--- a/tests/test_fetch_units.py
+++ b/tests/test_fetch_units.py
@@ -1,0 +1,40 @@
+from unittest.mock import Mock, patch
+
+from wcr_data_extraction import fetcher
+
+
+def test_fetch_unit_details_adds_missing_trait_description():
+    html = """
+        <div class=\"mini-section\">
+            <h2>Traits</h2>
+            <div class=\"mini-trait-tile\">
+                <div class=\"detail-info\">Brambles</div>
+                <div class=\"mini-talent__description\">Root foes for 3s</div>
+            </div>
+        </div>
+    """
+    mock_response = Mock(status_code=200, text=html)
+
+    mock_session = Mock()
+    mock_session.get.return_value = mock_response
+    with patch.object(fetcher, "create_session", return_value=mock_session), patch(
+        "wcr_data_extraction.fetcher.load_categories",
+        return_value={
+            "faction": {},
+            "type": {},
+            "trait": {"Brambles": "brambles"},
+            "speed": {},
+            "trait_desc": {"brambles": None},
+        },
+    ):
+        cats = fetcher.load_categories()
+        details = fetcher.fetch_unit_details(
+            "https://example.com/unit", cats, session=mock_session
+        )
+        mock_session.get.assert_called_once_with(
+            "https://example.com/unit",
+            headers={"User-Agent": "Mozilla/5.0"},
+            timeout=10,
+        )
+
+    assert details["trait_descriptions"] == {"brambles": "Root foes for 3s"}


### PR DESCRIPTION
## Summary
- merge trait descriptions correctly when categories have `null`
- test storing descriptions when categories omit them
- document fix in CHANGELOG

## Testing
- `pre-commit run --files src/wcr_data_extraction/fetcher.py tests/test_fetch_units.py CHANGELOG.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860173b077c832f9e6adf1cb7781641